### PR TITLE
Removed post endpoint for registering paper feedback

### DIFF
--- a/src/main/scala/devnull/Resources.scala
+++ b/src/main/scala/devnull/Resources.scala
@@ -35,7 +35,7 @@ class Resources(feedbackResource: SessionFeedbackResource, eventFeedbackResource
   override def intent: Intent = cors(Intent {
     case Root() => PingResource.handlePing()
     case Links.AppInfo() => AppInfo.handelAppInfo()
-    case Links.Event(eventId) => eventFeedbackResource.handleFeedback(eventId)
+//    case Links.Event(eventId) => eventFeedbackResource.handleFeedback(eventId)
     case Links.Feedbacks(eventId, sessionId) => feedbackResource.handleFeedbacks(eventId, sessionId)
     case _ => failure(NotFound)
   })


### PR DESCRIPTION
The endpoint is secured and should not be used for some
time now. This is a poor mans security :) The plan is
to add basic auth or something simular in the future.